### PR TITLE
Feature: Add ARM64 support to platform map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "surfer": "./dist/index.js"
   },
   "scripts": {
+    "prepare": "npm run build"
     "test": "jest",
     "test:dev": "jest --watch",
     "build": "tsc && chmod +x ./dist/index.js && cp src/commands/license-check.txt dist/commands/license-check.txt",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "surfer": "./dist/index.js"
   },
   "scripts": {
-    "prepare": "npm run build"
+    "prepare": "npm run build",
     "test": "jest",
     "test:dev": "jest --watch",
     "build": "tsc && chmod +x ./dist/index.js && cp src/commands/license-check.txt dist/commands/license-check.txt",

--- a/src/commands/patches/branding-patch.ts
+++ b/src/commands/patches/branding-patch.ts
@@ -453,7 +453,7 @@ function setUpdateURLs() {
       suffix = '-aarch64';
     }
   }
-  const baseURL = `URL=https://@MOZ_APPUPDATE_HOST@/updates/browser/%BUILD_TARGET%/%CHANNEL%${sufix}/update.xml`
+  const baseURL = `URL=https://@MOZ_APPUPDATE_HOST@/updates/browser/%BUILD_TARGET%/%CHANNEL%${suffix}/update.xml`
   const appIni = join(ENGINE_DIR, 'build', 'application.ini.in')
   const appIniContents = readFileSync(appIni).toString()
   const updatedAppIni = appIniContents.replace(/URL=.*update.xml/g, baseURL)

--- a/src/commands/patches/branding-patch.ts
+++ b/src/commands/patches/branding-patch.ts
@@ -422,8 +422,37 @@ pref("devtools.selfxss.count", 5);
 }
 
 function setUpdateURLs() {
-  const sufix =
-    compatMode && (process as any).surferPlatform !== 'macos' ? '-generic' : ''
+  let suffix;
+  if ((process as any).surferPlatform == 'win32') {
+    if (compatMode == 'x86_64') {
+      suffix = '-generic';
+    }
+    else if (compatMode == 'x86_64-v3') {
+      suffix = '';
+    }
+    else if (compatMode == 'aarch64') {
+      suffix = '-aarch64';
+    }
+  }
+  if ((process as any).surferPlatform == 'linux') {
+    if (compatMode == 'x86_64') {
+      suffix = '-generic';
+    }
+    else if (compatMode == 'aarch64') {
+      suffix = '';
+    }
+  }
+  if ((process as any).surferPlatform == 'linux') {
+    if (compatMode == 'x86_64') {
+      suffix = '-generic';
+    }
+    else if (compatMode == 'x86_64-v3') {
+      suffix = '';
+    }
+    else if (compatMode == 'aarch64') {
+      suffix = '-aarch64';
+    }
+  }
   const baseURL = `URL=https://@MOZ_APPUPDATE_HOST@/updates/browser/%BUILD_TARGET%/%CHANNEL%${sufix}/update.xml`
   const appIni = join(ENGINE_DIR, 'build', 'application.ini.in')
   const appIniContents = readFileSync(appIni).toString()

--- a/src/commands/updates/browser.ts
+++ b/src/commands/updates/browser.ts
@@ -151,19 +151,19 @@ async function writeUpdateFileToDisk(
     if (compatMode == 'x86_64') {
       suffix = '-generic';
     }
-    else if (compatMode == 'aarch64') {
-      suffix = '';
-    }
-  }
-  if ((process as any).surferPlatform == 'linux') {
-    if (compatMode == 'x86_64') {
-      suffix = '-generic';
-    }
     else if (compatMode == 'x86_64-v3') {
       suffix = '';
     }
     else if (compatMode == 'aarch64') {
       suffix = '-aarch64';
+    }
+  }
+  if ((process as any).surferPlatform == 'darwin') {
+    if (compatMode == 'x86_64') {
+      suffix = '-generic';
+    }
+    else if (compatMode == 'aarch64') {
+      suffix = '';
     }
   }
   const xmlPath = join(

--- a/src/commands/updates/browser.ts
+++ b/src/commands/updates/browser.ts
@@ -74,7 +74,7 @@ function getReleaseMarName(releaseInfo: ReleaseInfo): string | undefined {
     case 'darwin': {
       switch (compatMode) {
         case 'x86_64': {
-          releaseInfo.archives['macos-x64']
+          releaseInfo.archives['macos-x86_64']
         }
         case 'aarch64': {
           releaseInfo.archives['macos-aarch64'] 

--- a/src/commands/updates/browser.ts
+++ b/src/commands/updates/browser.ts
@@ -189,9 +189,10 @@ function getTargets(): string[] {
     return ausPlatformsMap.linux
   }
 
-  if ((process as any).surferPlatform == 'macos') {
+  if ((process as any).surferPlatform == 'darwin') {
     return ausPlatformsMap.macos
   }
+  return ausPlatformsMap.macos
 }
 
 export async function generateBrowserUpdateFiles() {

--- a/src/commands/updates/browser.ts
+++ b/src/commands/updates/browser.ts
@@ -192,6 +192,7 @@ function getTargets(): string[] {
   if ((process as any).surferPlatform == 'macos') {
     return ausPlatformsMap.macos
   }
+}
 
 export async function generateBrowserUpdateFiles() {
   log.info('Creating browser AUS update files')

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export const bin_name = BIN_NAME
 
 const programVersions = []
 
-export const compatMode = process.env.SURFER_COMPAT == 'true'
+export const compatMode = process.env.SURFER_COMPAT
 
 for (const brand in config.brands) {
   const brandConfig = config.brands[brand]

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -67,7 +67,7 @@ export interface ReleaseInfo {
     'windows-arm64'?: string
 
     'macos-aarch64'?: string
-    'macos-x64'?: string
+    'macos-x86_64'?: string
 
     linux?: string
     'linux-compat'?: string

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -63,12 +63,15 @@ export interface ReleaseInfo {
 
   archives?: {
     windows?: string
+    'windows-compat'?: string
+    'windows-arm64'?: string
+
     'macos-aarch64'?: string
     'macos-x64'?: string
-    linux?: string
 
-    'windows-compat'?: string
+    linux?: string
     'linux-compat'?: string
+    'linux-aarch64'?: string
   }
 }
 


### PR DESCRIPTION
Added Windows and Linux ARM64 support to platform map and changed SURFER_COMPAT to be the architecture instead of true/false and the ternary operators based on it to if/elseif statements for each arch since they assumed there's only be two builds per OS, this also makes it easier to add more if you also wanted to add a AVX512 x86_64-v4 build as well like mentioned in zen-browser/desktop#750