### PR TITLE
Fix update urls

### DIFF
--- a/src/commands/patches/branding-patch.ts
+++ b/src/commands/patches/branding-patch.ts
@@ -422,7 +422,7 @@ pref("devtools.selfxss.count", 5);
 }
 
 function setUpdateURLs() {
-  let suffix;
+  let suffix = '';
   if ((process as any).surferPlatform == 'win32') {
     if (compatMode == 'x86_64') {
       suffix = '-generic';


### PR DESCRIPTION
You missed this while refactoring, the non-generic builds are looking for twilightundefinied since the suffix doesn't have a value.