### PR TITLE
fix: hard fail when committing fails

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -65,6 +65,8 @@ export const init = async (directory: Command | string): Promise<void> => {
   await configDispatch('git', {
     args: ['commit', '-aqm', `"Firefox ${version}"`],
     cwd: absoluteInitDirectory,
+    // Committing can fail for configuration issues: see https://github.com/zen-browser/desktop/issues/1877
+    killOnError: true,
   })
 
   await configDispatch('git', {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -60,6 +60,11 @@ export const init = async (directory: Command | string): Promise<void> => {
     cwd: absoluteInitDirectory,
   })
 
+  await configDispatch('git', {
+    args: ['config', 'core.safecrlf', 'false'],
+    cwd: absoluteInitDirectory,
+  })
+
   log.info('Committing...')
 
   await configDispatch('git', {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { bin_name } from '..'
 import { log } from '../log'
-import { config, configDispatch, dynamicConfig } from '../utils'
+import { config, configDispatch } from '../utils'
 
 export const init = async (directory: Command | string): Promise<void> => {
   const cwd = process.cwd()
@@ -46,17 +46,17 @@ export const init = async (directory: Command | string): Promise<void> => {
   })
 
   await configDispatch('git', {
-    args: ['init'],
-    cwd: absoluteInitDirectory,
-  })
-
-  await configDispatch('git', {
     args: ['checkout', '--orphan', version],
     cwd: absoluteInitDirectory,
   })
 
   await configDispatch('git', {
     args: ['add', '-f', '.'],
+    cwd: absoluteInitDirectory,
+  })
+
+  await configDispatch('git', {
+    args: ['config', 'commit.gpgsign', 'false'],
     cwd: absoluteInitDirectory,
   })
 


### PR DESCRIPTION
Ensures that we hard fail when adding the initial commit for the firefox repo.
Also handles the case where `commit.gpgSign` is set to `true` globally and overrides it.

Reference: https://github.com/zen-browser/desktop/issues/1877 and https://github.com/zen-browser/surfer/issues/5
