### PR TITLE
chore: include output in configDispatch

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -129,11 +129,11 @@ const genericBuild = async (os: string, fast = false): Promise<boolean> => {
     `Mach contents: \n ${readFileSync(join(ENGINE_DIR, 'mach'))}\n\n===END===`
   )
 
-  return await configDispatch('./mach', {
+  return (await configDispatch('./mach', {
     args: buildOptions,
     cwd: ENGINE_DIR,
     killOnError: true,
-  })
+  })).success
 }
 
 const parseDate = (d: number) => {


### PR DESCRIPTION
allows for acting on the output after executing a command. This will be
useful with https://github.com/zen-browser/surfer/pull/15 to only apply
`commit.gpgSign false` if a gpg key is not present in the config.
