### PR TITLE
simple syntax fix in Build.ts

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -31,7 +31,7 @@ const applyConfig = async (os: string) => {
 
   try {
     // Retrieve changeset
-    const { stdout } = await execa('git', ['rev-parse', 'HEAD'])
+    const { stdout } = await execa('git', ['rev-parse','--', 'HEAD'])
     changeset = stdout.trim()
   } catch (error) {
     log.warning(


### PR DESCRIPTION
Maybe the git CLI has updated the syntax and gives an error, which states, that there should be a '--' where it's inserted.