### PR TITLE
Fix shouldUseCandidate method causing surfer download command to fail

### DIFF
--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -19,6 +19,7 @@ export const shouldUseCandidate = (): boolean => {
   const brandingKey = dynamicConfig.get('brand')
   return (
     brandingKey !== 'release' &&
+    config.version.candidate !== undefined &&
     config.version.version !== config.version.candidate
   )
 }


### PR DESCRIPTION
Updates the logic behind determining if a build should use a build candidate or release. Previously the code would fail preventing surfer users from starting projects as the download set would fail.