### PR TITLE
Removed depricated lines from mozconfig that prevent builds from running

### DIFF
--- a/template/configs/common/mozconfig
+++ b/template/configs/common/mozconfig
@@ -1,9 +1,6 @@
 ac_add_options --with-app-name=${binName}
 export MOZ_USER_DIR="${name}"
-export MOZ_APP_VENDOR="${vendor}"
 export MOZ_APP_BASENAME=${binName}
-export MOZ_APP_PROFILE=${binName}
-export MOZ_MACBUNDLE_ID=${appId}
 export MOZ_DISTRIBUTION_ID=${appId}
 
 # Uncomment if builds are too resource hungry


### PR DESCRIPTION
I removed lines from the mozconfig that Firefox now supposedly infers. 