### PR TITLE
Updated theme patch files for current firefox version

### DIFF
--- a/template/src/browser/themes.optional/linux/browser-css.patch
+++ b/template/src/browser/themes.optional/linux/browser-css.patch
@@ -1,13 +1,13 @@
 diff --git a/browser/themes/linux/browser.css b/browser/themes/linux/browser.css
-index ed31817d9e2be619d0d3e8f3b51a6e6d29ff22c3..711073553c5f1aff54337526985d2076facb8cba 100644
+index 5e5d397876..641a7edc63 100644
 --- a/browser/themes/linux/browser.css
 +++ b/browser/themes/linux/browser.css
-@@ -7,6 +7,8 @@
- 
- @namespace html url("http://www.w3.org/1999/xhtml");
+@@ -5,6 +5,8 @@
+ @import url("chrome://browser/skin/browser-shared.css");
+ @import url("chrome://browser/skin/contextmenu.css");
  
 +%include ../custom/linux/linux.inc.css
 +
  /**
-  * We intentionally do not include browser-custom-colors.css,
-  * instead choosing to fall back to system colours and transparencies
+  * We still want to do some of the tweaks that browser-colors does, like
+  * disabling the toolbar field border and backgrounds.

--- a/template/src/browser/themes.optional/linux/jar-mn.patch
+++ b/template/src/browser/themes.optional/linux/jar-mn.patch
@@ -1,11 +1,11 @@
 diff --git a/browser/themes/linux/jar.mn b/browser/themes/linux/jar.mn
-index 404a88b218c652afac0cb2004676d22da53d48f3..5a4668ef2970dd773536907f51f3e7e7e3e023cb 100644
+index 0a6465a26f..e9f6e8d735 100644
 --- a/browser/themes/linux/jar.mn
 +++ b/browser/themes/linux/jar.mn
-@@ -6,7 +6,7 @@ browser.jar:
+@@ -5,7 +5,7 @@
+ browser.jar:
  % skin browser classic/1.0 %skin/classic/browser/
  #include ../shared/jar.inc.mn
-   skin/classic/browser/sanitizeDialog.css
 -  skin/classic/browser/browser.css
 +* skin/classic/browser/browser.css
    skin/classic/browser/contextmenu.css                (../shared/contextmenu.css)

--- a/template/src/browser/themes.optional/osx/browser-css.patch
+++ b/template/src/browser/themes.optional/osx/browser-css.patch
@@ -1,13 +1,14 @@
 diff --git a/browser/themes/osx/browser.css b/browser/themes/osx/browser.css
-index f9860d3e66e8db7ee32d073bfe48704d16a47106..da0c36b7413aa910b2fd339e2735fcce744f5a4e 100644
+index 486e269838..c7535a74d9 100644
 --- a/browser/themes/osx/browser.css
 +++ b/browser/themes/osx/browser.css
-@@ -7,6 +7,8 @@
+@@ -4,6 +4,9 @@
  
- @namespace html url("http://www.w3.org/1999/xhtml");
+ @import url("chrome://browser/skin/browser-shared.css");
  
 +%include ../custom/macos/macos.inc.css
 +
++
  :root {
-   --toolbar-non-lwt-bgcolor: -moz-dialog;
-   --toolbar-non-lwt-textcolor: -moz-dialogtext;
+   --panel-field-background: light-dark(rgba(249, 249, 250, 0.3), rgba(12, 12, 13, 0.3));
+ }

--- a/template/src/browser/themes.optional/osx/jar-mn.patch
+++ b/template/src/browser/themes.optional/osx/jar-mn.patch
@@ -1,13 +1,13 @@
 diff --git a/browser/themes/osx/jar.mn b/browser/themes/osx/jar.mn
-index 6245c67a8d2957e301f9888603f504ce091fb70c..0288241dcb3e9e4603df36b04e1f6b476e935a30 100644
+index 9b8fa9fa05..03d37d9b86 100644
 --- a/browser/themes/osx/jar.mn
 +++ b/browser/themes/osx/jar.mn
-@@ -6,7 +6,7 @@ browser.jar:
+@@ -5,7 +5,7 @@
+ browser.jar:
  % skin browser classic/1.0 %skin/classic/browser/
  #include ../shared/jar.inc.mn
-   skin/classic/browser/sanitizeDialog.css
 -  skin/classic/browser/browser.css
 +* skin/classic/browser/browser.css
-   skin/classic/browser/browser-custom-colors.css     (../shared/browser-custom-colors.css)
-   skin/classic/browser/pageInfo.css
    skin/classic/browser/customizableui/panelUI.css    (customizableui/panelUI.css)
+   skin/classic/browser/downloads/allDownloadsView.css (downloads/allDownloadsView.css)
+   skin/classic/browser/downloads/downloads.css              (downloads/downloads.css)

--- a/template/src/browser/themes.optional/shared/browser-shared-css.patch
+++ b/template/src/browser/themes.optional/shared/browser-shared-css.patch
@@ -1,13 +1,14 @@
 diff --git a/browser/themes/shared/browser-shared.css b/browser/themes/shared/browser-shared.css
-index 946807ef8623b49c2ad9c72374a38be2942ca012..1ceda5f77b57d34d841e141bf5ac531b68f44189 100644
+index 2287d8f9fd..d8bbb3aa16 100644
 --- a/browser/themes/shared/browser-shared.css
 +++ b/browser/themes/shared/browser-shared.css
-@@ -24,6 +24,8 @@
- 
- @namespace html url("http://www.w3.org/1999/xhtml");
+@@ -34,6 +34,9 @@
+ @import url("chrome://browser/skin/UITour.css");
+ @import url("chrome://browser/skin/formautofill-notification.css");
  
 +%include ../custom/shared/shared.inc.css
 +
- :root {
-   --toolbar-bgcolor: var(--toolbar-non-lwt-bgcolor);
-   --toolbar-bgimage: var(--toolbar-non-lwt-bgimage);
++
+ :root,
+ body {
+   height: 100%;

--- a/template/src/browser/themes.optional/shared/jar-inc-mn.patch
+++ b/template/src/browser/themes.optional/shared/jar-inc-mn.patch
@@ -1,13 +1,13 @@
 diff --git a/browser/themes/shared/jar.inc.mn b/browser/themes/shared/jar.inc.mn
-index 14ef7ff731145a42b28cbb9afe192bf56f756ed5..9bfb7cdfaef3688c2064320f85b9196daf8a8215 100644
+index e3bdc11e44..a7d086f3b8 100644
 --- a/browser/themes/shared/jar.inc.mn
 +++ b/browser/themes/shared/jar.inc.mn
-@@ -15,7 +15,7 @@
-   skin/classic/browser/addon-notification.css                  (../shared/addon-notification.css)
-   skin/classic/browser/autocomplete.css                        (../shared/autocomplete.css)
+@@ -18,7 +18,7 @@
+   skin/classic/browser/aiWindowSidebar.css                     (../shared/aiWindowSidebar.css)
    skin/classic/browser/blockedSite.css                         (../shared/blockedSite.css)
+   skin/classic/browser/browser-colors.css                      (../shared/browser-colors.css)
 -  skin/classic/browser/browser-shared.css                      (../shared/browser-shared.css)
 +* skin/classic/browser/browser-shared.css                      (../shared/browser-shared.css)
-   skin/classic/browser/ctrlTab.css                             (../shared/ctrlTab.css)
-   skin/classic/browser/light-dark-overrides.css                (../shared/light-dark-overrides.css)
+   skin/classic/browser/formautofill-notification.css           (../shared/formautofill-notification.css)
+   skin/classic/browser/identity-credential-notification.css    (../shared/identity-credential-notification.css)
    skin/classic/browser/menupanel.css                           (../shared/menupanel.css)

--- a/template/src/browser/themes.optional/windows/browser-css.patch
+++ b/template/src/browser/themes.optional/windows/browser-css.patch
@@ -1,13 +1,14 @@
 diff --git a/browser/themes/windows/browser.css b/browser/themes/windows/browser.css
-index fe2eaa0ef90733894fc026e694beae4a079d78c4..f3be10989da624b9a8b50923cbb5e583d6006726 100644
+index 7dcb386d38..2d91f1f7b6 100644
 --- a/browser/themes/windows/browser.css
 +++ b/browser/themes/windows/browser.css
-@@ -8,6 +8,8 @@
- 
- @namespace html url("http://www.w3.org/1999/xhtml");
+@@ -5,6 +5,9 @@
+ @import url("chrome://browser/skin/browser-shared.css");
+ @import url("chrome://browser/skin/contextmenu.css");
  
 +%include ../custom/windows/windows.inc.css
 +
- :root {
-   --toolbar-non-lwt-bgcolor: -moz-dialog;
-   --toolbar-non-lwt-textcolor: -moz-dialogtext;
++
+ #menubar-items {
+   flex-direction: column; /* for flex hack */
+   justify-content: normal; /* align the menubar to the top also in customize mode */

--- a/template/src/browser/themes.optional/windows/jar-mn.patch
+++ b/template/src/browser/themes.optional/windows/jar-mn.patch
@@ -1,13 +1,13 @@
 diff --git a/browser/themes/windows/jar.mn b/browser/themes/windows/jar.mn
-index 9133c04c3062b00ef801f18a932e0a0933625560..b993c0a7fcd6777ee64a076fd843d7c572088746 100644
+index 7d44c52adf..c75ec7edbb 100644
 --- a/browser/themes/windows/jar.mn
 +++ b/browser/themes/windows/jar.mn
-@@ -6,7 +6,7 @@ browser.jar:
+@@ -5,7 +5,7 @@
+ browser.jar:
  % skin browser classic/1.0 %skin/classic/browser/
  #include ../shared/jar.inc.mn
-   skin/classic/browser/sanitizeDialog.css
 -  skin/classic/browser/browser.css
 +* skin/classic/browser/browser.css
-   skin/classic/browser/browser-custom-colors.css  (../shared/browser-custom-colors.css)
-   skin/classic/browser/browser-aero.css
    skin/classic/browser/contextmenu.css            (../shared/contextmenu.css)
+   skin/classic/browser/monitor-base.png
+   skin/classic/browser/monitor-border.png


### PR DESCRIPTION
The theming patches were outdated with the patches referencing lines that no longer existed, so i went in and re-generated the patches and updated the template files.